### PR TITLE
Includes 'user_list' attribute.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,4 +22,8 @@ suites:
     attributes:
       users:
         user_list:
-          - test
+          - alice
+          - bob
+          # NOTE: omitting user "carol" for tests
+          - dan
+          # NOTE: including user without data bag

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,3 +19,7 @@ suites:
     data_bags_path: "test/integration/data_bags"
     run_list:
       - recipe[cop_users]
+    attributes:
+      users:
+        user_list:
+          - test

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,3 @@
 default['users']['group']['admin'] = 'adm'
+
+default['users']['user_list'] = {}

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.0.1'
+version             '0.0.2'
 source_url          'https://github.com/copious-cookbooks/users'
 issues_url          'https://github.com/copious-cookbooks/users/issues'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,7 @@ end
 
 users.each do |u|
     user = data_bag_item('users', u)
-    if user_list.include?(user['id'])
+    if user_list.include?(u)
         home = "/home/#{user['id']}"
         admin_users << user['id'] if user['groups'] && user['groups'].include?('sudo')
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,6 +9,13 @@ users     = data_bag('users')
 admin_users = []
 admin_group = node['users']['group']['admin']
 
+# Check that each user in user_list has a corresponding data bag
+user_list.each do |ul|
+    unless users.include?(ul)
+        Chef::Log.warn("User #{ul} has no corresponding data bag, skipping")
+    end
+end
+
 users.each do |u|
     user = data_bag_item('users', u)
     if user_list.include?(user['id'])

--- a/test/integration/data_bags/users/alice.json
+++ b/test/integration/data_bags/users/alice.json
@@ -1,0 +1,7 @@
+{
+    "id": "alice",
+    "action": "create",
+    "comment": "Alice Adams",
+    "groups": ["sudo"],
+    "ssh_keys": ["ssh-rsa alice-key"]
+}

--- a/test/integration/data_bags/users/bob.json
+++ b/test/integration/data_bags/users/bob.json
@@ -1,0 +1,7 @@
+{
+    "id": "bob",
+    "action": "create",
+    "comment": "Bob Baker",
+    "groups": ["sudo"],
+    "ssh_keys": ["ssh-rsa bob-key"]
+}

--- a/test/integration/data_bags/users/carol.json
+++ b/test/integration/data_bags/users/carol.json
@@ -1,0 +1,7 @@
+{
+    "id": "carol",
+    "action": "create",
+    "comment": "Carol Carter",
+    "groups": ["sudo"],
+    "ssh_keys": ["ssh-rsa carol-key"]
+}

--- a/test/integration/data_bags/users/fail.json
+++ b/test/integration/data_bags/users/fail.json
@@ -1,0 +1,7 @@
+{
+    "id": "fail",
+    "action": "create",
+    "comment": "Fail User",
+    "groups": ["sudo"],
+    "ssh_keys": ["ssh-rsa FAIL-KEY"]
+}

--- a/test/integration/data_bags/users/fail.json
+++ b/test/integration/data_bags/users/fail.json
@@ -1,7 +1,0 @@
-{
-    "id": "fail",
-    "action": "create",
-    "comment": "Fail User",
-    "groups": ["sudo"],
-    "ssh_keys": ["ssh-rsa FAIL-KEY"]
-}

--- a/test/integration/data_bags/users/test.json
+++ b/test/integration/data_bags/users/test.json
@@ -1,7 +1,0 @@
-{
-    "id": "test",
-    "action": "create",
-    "comment": "Test User",
-    "groups": ["sudo"],
-    "ssh_keys": ["ssh-rsa TEST-KEY"]
-}

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -23,4 +23,12 @@ describe 'users::default' do
         it { should be_owned_by 'test' }
         it { should be_grouped_into 'test' }
     end
+
+    describe user('fail') do
+        it { should_not exist }
+    end
+
+    describe file('/home/fail/.ssh') do
+        it { should_not exist }
+    end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,34 +1,34 @@
 require 'spec_helper'
 
 describe 'users::default' do
-    describe user('test') do
+    describe user('alice') do
         it { should exist }
-        it { should belong_to_group 'test' }
-        it { should have_home_directory "/home/test" }
+        it { should belong_to_group 'adm' }
+        it { should have_home_directory '/home/alice' }
     end
 
-    describe file('/home/test/.ssh') do
+    describe file('/home/alice/.ssh') do
         it { should be_directory }
         it { should exist }
         it { should be_mode 700 }
-        it { should be_owned_by 'test' }
-        it { should be_grouped_into 'test' }
+        it { should be_owned_by 'alice' }
+        it { should be_grouped_into 'alice' }
     end
 
-    describe file('/home/test/.ssh/authorized_keys') do
+    describe file('/home/alice/.ssh/authorized_keys') do
         it { should be_file }
         it { should exist }
-        it { should contain 'ssh-rsa TEST-KEY' }
+        it { should contain 'ssh-rsa alice-key' }
         it { should be_mode 600 }
-        it { should be_owned_by 'test' }
-        it { should be_grouped_into 'test' }
+        it { should be_owned_by 'alice' }
+        it { should be_grouped_into 'alice' }
     end
 
-    describe user('fail') do
+    describe user('carol') do
         it { should_not exist }
     end
 
-    describe file('/home/fail/.ssh') do
+    describe file('/home/carol/.ssh') do
         it { should_not exist }
     end
 end


### PR DESCRIPTION
This pull request includes an attribute `node['users']['user_list']` that specifies which data bags to include. This attribute can be assigned on a per-environment basis to include or exclude users as needed. Chef will produce a warning if a user in the `user_list` does not have a corresponding data bag.

Example:
```
default_attributes(
    users:
        user_list: %w(
            alice
            bob
            dan
        )
```

Additionally, Kitchen tests have been updated with a `users` data bag ('carol') that is excluded from the `user_list` attribute, as well as passing tests to verify that this user is not created.