### PR TITLE
Fix/groups

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -27,3 +27,7 @@ suites:
           # NOTE: omitting user "carol" for tests
           - dan
           # NOTE: including user without data bag
+        group_list:
+          - sudo
+          - engineers
+          - umbrella

--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@ default_attributes(
 ```
 The `user_list` is based on the name of the data-bag, it has no knowledge of the contents. Make sure that your `user_list` references data-bag names and not expected user ID's.
 
+### Group List
+
+The `node['users']['group_list']` attribute controls which groups will be updated during the `cop_users` run. This attribute can be set on a per environment basis to include or exclude groups from different environments. If a user is included in the `user_list` attribute and has the corresponding group in their `groups` data-bag attribute, they will be assigned to this group. If the user has an item in their `groups` attribute which is not included in the `group_list`, no action will take place. By default, a user is included in their own group regardless of whether this is present in either the `group_list` or their own `groups` attribute. Example:
+```
+$ cat chef/environments/staging.rb
+default_attributes(
+    ...
+    users: {
+        ...
+        group_list: %w(
+            sudo
+            engineers
+            accounting
+        )
+    },
+    ...
+```
+
+
 ### Data Bag Format
 
 This recipe expects a data bag in the following format:
@@ -51,7 +70,7 @@ This recipe expects a data bag in the following format:
     "id": "test",
     "action": "create",
     "comment": "Test User",
-    "groups": ["sudo"],
+    "groups": ["sudo", "engineers", "finance"],
     "ssh_keys": ["ssh-rsa TEST-KEY"]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -16,9 +16,31 @@ Create data-bags for each user to be managed. The following data structure is as
 .
 └── data_bags
     └── users
-        ├── user1.json
-        └── user2.json
+        ├── amy.json
+        ├── bob.json
+        ├── carl.json
+        ├── dumplefweez.json
+        └── ed.json
 ```
+
+### User List
+
+The `node['users']['user_list']` attribute controls which data-bags will be included in the `cop_users` run. This attribute can be set on a per-environment basis to include or exclude users from different environments. For example:
+```
+$ cat chef/environments/staging.rb
+default_attributes(
+    ...
+    users: {
+        user_list: %w(
+            amy
+            bob
+            carl
+            ed
+        )
+    },
+    ...
+```
+The `user_list` is based on the name of the data-bag, it has no knowledge of the contents. Make sure that your `user_list` references data-bag names and not expected user ID's.
 
 ### Data Bag Format
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,2 @@
-default['users']['group']['admin'] = 'adm'
-
 default['users']['user_list'] = {}
+default['users']['group_list'] = {}

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,8 +6,7 @@
 user_list = node['users']['user_list']
 users     = data_bag('users')
 
-admin_users = []
-admin_group = node['users']['group']['admin']
+group_list = node['users']['group_list']
 
 # Check that each user in user_list has a corresponding data bag
 user_list.each do |ul|

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,6 +33,13 @@ users.each do |u|
                 comment     user['comment']
                 manage_home true
             end
+
+            # Include user in their own group
+            group user['id'] do
+                group_name user['id']
+                action     :create
+                members    user['id']
+            end
         end
 
         case user['action']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,13 +19,12 @@ users.each do |u|
     user = data_bag_item('users', u)
     if user_list.include?(u)
         home = "/home/#{user['id']}"
-        admin_users << user['id'] if user['groups'] && user['groups'].include?('sudo')
 
         user_exists = (`id #{user['id']} || echo 'false'`.strip != 'false')
 
         if user['action'].to_s != 'create' && !user_exists
             admin_user.delete(user['id'])
-            Chef::Log.warn("Skipping action: '#{user['action']}' of no-existing user '#{user['id']}'")
+            Chef::Log.warn("Skipping action: '#{user['action']}' of non-existing user '#{user['id']}'")
         else
             user user['id'] do
                 home        home
@@ -72,15 +71,25 @@ users.each do |u|
     end
 end
 
-# Add 'vagrant' user to admin group when in development environment
-if node.chef_environment == "development"
-    admin_users << 'vagrant'
-end
-
 # NOTE: Members are reassigned each Chef run, not appeneded
-# Add users to admin group
-group "Admin for users: #{admin_users.join(', ')}" do
-    group_name admin_group
-    action     :modify
-    members    admin_users
+group_list.each do |g|
+    # Wipe member_list for each group
+    member_list = []
+
+    users.each do |u|
+        user = data_bag_item('users', u)
+        # Check that user_list allows user
+        if user_list.include?(u)
+            if user['groups'].include?(g)
+                member_list << user['id']
+            end
+        end
+    end
+
+    # Assign member_list to group
+    group g do
+        group_name g
+        action     :create
+        members    member_list
+    end
 end

--- a/test/integration/data_bags/users/alice.json
+++ b/test/integration/data_bags/users/alice.json
@@ -2,6 +2,6 @@
     "id": "alice",
     "action": "create",
     "comment": "Alice Adams",
-    "groups": ["sudo"],
+    "groups": ["sudo", "umbrella", "accounting"],
     "ssh_keys": ["ssh-rsa alice-key"]
 }

--- a/test/integration/data_bags/users/bob.json
+++ b/test/integration/data_bags/users/bob.json
@@ -2,6 +2,6 @@
     "id": "bob",
     "action": "create",
     "comment": "Bob Baker",
-    "groups": ["sudo"],
+    "groups": ["sudo", "umbrella", "engineers"],
     "ssh_keys": ["ssh-rsa bob-key"]
 }

--- a/test/integration/data_bags/users/carol.json
+++ b/test/integration/data_bags/users/carol.json
@@ -2,6 +2,6 @@
     "id": "carol",
     "action": "create",
     "comment": "Carol Carter",
-    "groups": ["sudo"],
+    "groups": ["lunch", "engineers"],
     "ssh_keys": ["ssh-rsa carol-key"]
 }

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 describe 'users::default' do
     describe user('alice') do
         it { should exist }
-        it { should belong_to_group 'adm' }
+        it { should belong_to_group 'alice' }
+        it { should belong_to_group 'sudo' }
+        it { should belong_to_group 'umbrella' }
         it { should have_home_directory '/home/alice' }
     end
 


### PR DESCRIPTION
This pull request includes an attribute `group_list` that specifies which groups to manage. If a users data-bag attribute `groups` includes an item in this list, the user will be included in that group. In addition, the user is by default included in their own group with no attribute necessary in the data-bag.

Includes a passing update to the Kitchen tests that checks for a user to be in multiple groups.