### PR TITLE
Fix for empty/missing "groups" attribute

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -28,6 +28,7 @@ suites:
           - dan
           # NOTE: including user without data bag
           - ed
+          - francis
         group_list:
           - sudo
           - engineers

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -27,6 +27,7 @@ suites:
           # NOTE: omitting user "carol" for tests
           - dan
           # NOTE: including user without data bag
+          - ed
         group_list:
           - sudo
           - engineers

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.0.3'
+version             '0.0.4'
 source_url          'https://github.com/copious-cookbooks/users'
 issues_url          'https://github.com/copious-cookbooks/users/issues'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -87,7 +87,7 @@ group_list.each do |g|
         user = data_bag_item('users', u)
         # Check that user_list allows user
         if user_list.include?(u)
-            if user['groups'].include?(g)
+            if user['groups'] && user['groups'].include?(g)
                 member_list << user['id']
             end
         end

--- a/test/integration/data_bags/users/ed.json
+++ b/test/integration/data_bags/users/ed.json
@@ -1,0 +1,6 @@
+{
+    "id": "ed",
+    "action": "create",
+    "comment": "Edward Edelweiss",
+    "ssh_keys": ["ssh-rsa ed-key"]
+}

--- a/test/integration/data_bags/users/francis.json
+++ b/test/integration/data_bags/users/francis.json
@@ -1,0 +1,7 @@
+{
+    "id": "francis",
+    "action": "create",
+    "comment": "Francis Franklin",
+    "groups": [],
+    "ssh_keys": ["ssh-rsa francis-key"]
+}


### PR DESCRIPTION
This PR addresses a user with a data-bag lacking the `groups` attribute. It includes two additional test users to check against a missing `groups` attribute, as well as an empty `groups` attribute.