### PR TITLE
Remove recursive execution of user permissions on `.config/`

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.0.4'
+version             '0.0.5'
 source_url          'https://github.com/copious-cookbooks/users'
 issues_url          'https://github.com/copious-cookbooks/users/issues'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -56,14 +56,6 @@ users.each do |u|
                     mode  0700
                 end
 
-                execute "set #{user['id']} as owner of homedir configs" do
-                    command "find #{home}/.config/ | xargs chown #{user['id']}; \
-                             find #{home}/.config/ -type f | xargs chmod 0600; \
-                             find #{home}/.config/ -type d | xargs chmod 0700"
-                    action  :run
-                    ignore_failure true
-                end
-
                 file "#{home}/.ssh/authorized_keys" do
                     owner   user['id']
                     group   user['id']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,7 +23,6 @@ users.each do |u|
         user_exists = (`id #{user['id']} || echo 'false'`.strip != 'false')
 
         if user['action'].to_s != 'create' && !user_exists
-            admin_user.delete(user['id'])
             Chef::Log.warn("Skipping action: '#{user['action']}' of non-existing user '#{user['id']}'")
         else
             user user['id'] do


### PR DESCRIPTION
Removes non-idempotent execution of recursive permission set on `~/.config/` contents. Additionally removes a leftover artifact from the previous update. Fixes #5