### PR TITLE
Guard against missing SSH keys

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -29,6 +29,7 @@ suites:
           # NOTE: including user without data bag
           - ed
           - francis
+          - gertrude
         group_list:
           - sudo
           - engineers

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.0.5'
+version             '0.0.6'
 source_url          'https://github.com/copious-cookbooks/users'
 issues_url          'https://github.com/copious-cookbooks/users/issues'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -55,12 +55,14 @@ users.each do |u|
                     mode  0700
                 end
 
-                file "#{home}/.ssh/authorized_keys" do
-                    owner   user['id']
-                    group   user['id']
-                    mode    0600
-                    content "# Chef generated file. Edits will be lost.\n#{user['ssh_keys'].join("\n")}"
-                    backup  false
+                if user['ssh_keys']
+                    file "#{home}/.ssh/authorized_keys" do
+                        owner   user['id']
+                        group   user['id']
+                        mode    0600
+                        content "# Chef generated file. Edits will be lost.\n#{user['ssh_keys'].join("\n")}"
+                        backup  false
+                    end
                 end
 
             when 'remove'

--- a/test/integration/data_bags/users/gertrude.json
+++ b/test/integration/data_bags/users/gertrude.json
@@ -1,0 +1,6 @@
+{
+    "id": "gertrude",
+    "action": "create",
+    "comment": "Gertrude Gershunkel",
+    "groups": ["nokeys"]
+}

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -33,4 +33,8 @@ describe 'users::default' do
     describe file('/home/carol/.ssh') do
         it { should_not exist }
     end
+
+    describe file('/home/gertrude/.ssh/authorized_keys') do
+        it { should_not exist }
+    end
 end


### PR DESCRIPTION
Updates recipe to check whether a users data bag has `ssh_keys` present before attempting to create `/home/user/.ssh/authorized_keys`. Additionally adds a test for this case as well as a test data bag for a user with no SSH key.

Fixes #12