### PR TITLE
Update/reload ohai

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.0.6'
+version             '0.0.7'
 source_url          'https://github.com/copious-cookbooks/users'
 issues_url          'https://github.com/copious-cookbooks/users/issues'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,6 +31,7 @@ users.each do |u|
                 action      user['action']
                 comment     user['comment']
                 manage_home true
+                notifies    :reload, 'ohai[reload_passwd]', :immediately
             end
 
             # Include user in their own group
@@ -38,6 +39,7 @@ users.each do |u|
                 group_name user['id']
                 action     :create
                 members    user['id']
+                notifies   :reload, 'ohai[reload_passwd]', :immediately
             end
         end
 
@@ -91,5 +93,12 @@ group_list.each do |g|
         group_name g
         action     :create
         members    member_list
+        notifies   :reload, 'ohai[reload_passwd]', :immediately
     end
+end
+
+# Reload ohai 'etc' plugin
+ohai 'reload_passwd' do
+    action :nothing
+    plugin 'etc'
 end


### PR DESCRIPTION
Fixes #14 by reloading Ohai `passwd` after modifications to users or groups. Verified with Kitchen, all tests continue to pass.